### PR TITLE
fix (#24) : 채팅메시지 orderBy 수정, Timestamp 타입수정

### DIFF
--- a/src/components/Chat/ChatMessage/index.tsx
+++ b/src/components/Chat/ChatMessage/index.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 import { ChatMessageItem } from './Styled';
 import { Avatar } from '@material-ui/core';
-import { MessageTimestamp } from 'types/Message';
 import { UserInfo } from 'types/User';
 import { Delete, Edit } from '@material-ui/icons';
 
@@ -9,7 +8,7 @@ interface Props {
   message: string;
   messageId: string;
   modify: boolean;
-  timestamp: MessageTimestamp;
+  timestamp: number;
   user: UserInfo;
   currentUserId: UserInfo;
   updateMessage: (messageId: string) => void;
@@ -26,7 +25,7 @@ const ChatMessage: FC<Props> = ({
   updateMessage,
   deleteMessage,
 }) => {
-  const messageTimeStamp = new Date(timestamp.seconds).toLocaleTimeString();
+  const messageTimeStamp = new Date(timestamp).toLocaleTimeString();
 
   return (
     <ChatMessageItem.Panel modify={user.uid === currentUserId.uid}>

--- a/src/components/Chat/index.tsx
+++ b/src/components/Chat/index.tsx
@@ -49,17 +49,12 @@ const Chat: FC = () => {
     if (!message) return;
     if (!channelId) return;
 
-    const timestamp = {
-      // 기존 timestamp와 형식을 맞춰주기 위해 임시 추가
-      // 채널수정,삭제 채팅 수정삭제 기능 추가 후 변경
-      seconds: new Date().getTime(),
-    };
     const messageIndex = channelMessage.length > 0 ? channelMessage.length : 0;
 
     const newMessage = {
       message,
       messageIndex,
-      timestamp,
+      timestamp: new Date().getTime(),
       user: userState,
     };
 
@@ -120,7 +115,7 @@ const Chat: FC = () => {
         .update({
           message: updateMessage,
           modify: true,
-          timestamp: { seconds: new Date().getTime() },
+          timestamp: new Date().getTime(),
         });
     },
     [channelMessage]
@@ -128,9 +123,7 @@ const Chat: FC = () => {
 
   return (
     <ChatScreen.Panel>
-      {/*  */}
       <ChatHeader channelName={channelName} />
-      {/*  */}
       <ChatScreen.MessageList>
         {channelMessage.map(
           (
@@ -152,7 +145,6 @@ const Chat: FC = () => {
         )}
         <div ref={scrollRef} />
       </ChatScreen.MessageList>
-      {/*  */}
       <ChatSendMessage
         value={message}
         channelName={channelName}
@@ -160,7 +152,6 @@ const Chat: FC = () => {
         sendMessage={sendMessage}
         disabled={channelId ? false : true}
       />
-      {/*  */}
     </ChatScreen.Panel>
   );
 };

--- a/src/components/Chat/index.tsx
+++ b/src/components/Chat/index.tsx
@@ -22,7 +22,7 @@ const Chat: FC = () => {
       db.collection('channels')
         .doc(channelId)
         .collection('messages')
-        .orderBy('timestamp', 'asc')
+        .orderBy('messageIndex', 'asc')
         .onSnapshot((snapshot) => {
           const docs: any = snapshot.docs.map((doc) =>
             Object.assign({}, doc.data(), {
@@ -54,9 +54,11 @@ const Chat: FC = () => {
       // 채널수정,삭제 채팅 수정삭제 기능 추가 후 변경
       seconds: new Date().getTime(),
     };
+    const messageIndex = channelMessage.length > 0 ? channelMessage.length : 0;
 
     const newMessage = {
       message,
+      messageIndex,
       timestamp,
       user: userState,
     };
@@ -70,6 +72,7 @@ const Chat: FC = () => {
           const combineResMessage = Object.assign({
             ...newMessage,
             messageId: res.id,
+            messageIndex: channelMessage.length,
           });
           setChannelMessage([...channelMessage, combineResMessage]);
           setMessage('');

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -10,6 +10,7 @@ export interface MessageTimestamp {
 export interface MessageType {
   message: string;
   messageId: string;
+  messageIndex: number;
   timestamp: MessageTimestamp;
   user: UserInfo;
   modify?: boolean;

--- a/src/types/Message.ts
+++ b/src/types/Message.ts
@@ -11,7 +11,7 @@ export interface MessageType {
   message: string;
   messageId: string;
   messageIndex: number;
-  timestamp: MessageTimestamp;
+  timestamp: number;
   user: UserInfo;
   modify?: boolean;
 }


### PR DESCRIPTION
1. 채팅메시지 입력시 messageIndex 추가
2. 채팅메시지 수정한 경우 순서가 바뀌는 현상 수정
3. 초기 구성에 사용하던 Timestamp Type 변경